### PR TITLE
Entity Shader v1.0

### DIFF
--- a/engine/entity.gd
+++ b/engine/entity.gd
@@ -30,11 +30,16 @@ var hitbox # to be defined by create_hitbox()
 onready var camera = get_parent().get_node("Camera")
 
 var texture_default = null
-var texture_hurt = null
+var entity_shader = preload("res://engine/entity.shader")
 
 func _ready():
 	texture_default = sprite.texture
-	texture_hurt = load(sprite.texture.get_path().replace(".png","_hurt.png"))
+	
+	# Create default material if one does not exist...
+	if !sprite.material:
+		sprite.material = ShaderMaterial.new()
+		sprite.material.set_shader(entity_shader)
+	
 	add_to_group("entity")
 	health = MAX_HEALTH
 	home_position = position
@@ -129,10 +134,10 @@ func loop_damage():
 				body.hit()
 
 sync func hurt_texture():
-	sprite.texture = texture_hurt
+	sprite.material.set_shader_param("is_hurt", true)
 
 sync func default_texture():
-	sprite.texture = texture_default
+	sprite.material.set_shader_param("is_hurt", false)
 
 func anim_switch(animation):
 	var newanim = str(animation,spritedir)

--- a/engine/entity.shader
+++ b/engine/entity.shader
@@ -1,0 +1,58 @@
+shader_type canvas_item;
+render_mode unshaded;
+
+uniform bool is_hurt = false;
+uniform bool custom_colors = false;
+
+uniform vec4 skin : hint_color = vec4(0.969, 0.71, 0.545, 1.0);
+uniform vec4 outline : hint_color = vec4(0.0, 0.0, 0.0, 1.0);
+uniform vec4 accent : hint_color = vec4(0.094, 0.522, 0.969, 1.0);
+
+uniform vec4 hurt_skin : hint_color = vec4(0.0, 0.0, 0.0, 1.0);
+uniform vec4 hurt_outline : hint_color = vec4(0.973, 0.69, 0.188, 1.0);
+uniform vec4 hurt_accent : hint_color = vec4(1.0, 0.0, 0.0, 1.0);
+
+vec4 hurt(vec4 base) {
+	float sum = base.r + base.g + base.b;
+	vec4 output;
+	
+	if(sum > 0.0){
+		if(sum > 2.0) {
+			output = hurt_skin;
+		} else {
+			output = hurt_accent;
+		}
+	} else {
+		output = hurt_outline;
+	}
+	
+	return output;
+}
+
+vec4 swap(vec4 base) {
+	vec4 output;
+	if(base.rgb == vec3(0.0)) {
+		output = outline;
+	} else {
+		if(base.rgb == vec3(1.0)) {
+			output = skin;
+		} else {
+			output = accent;
+		}
+	}
+	output.a = base.a;
+	return output;
+}
+
+void fragment() {
+	vec4 base = texture(TEXTURE, UV);
+	if(is_hurt) {
+		COLOR = vec4(mix(base, hurt(base), (sin(TIME * 25.0) + 1.0) / 2.0).rgb, base.a);
+	} else {
+		if(custom_colors) {
+			COLOR = swap(base);
+		} else {
+			COLOR = base;
+		}
+	}
+}

--- a/game.gd
+++ b/game.gd
@@ -39,7 +39,6 @@ func add_new_player(id):
 	
 	new_player.get_node("Sprite").texture = load(network.player_skins.get(id))
 	new_player.texture_default = load(network.player_skins.get(id))
-	new_player.texture_hurt = load(new_player.get_node("Sprite").texture.get_path().replace(".png","_hurt.png"))
 
 func remove_player(id):
 	get_node(str(id)).queue_free()


### PR DESCRIPTION
First iteration of this shader, with this colors can be swapped on the fly, and additional hurt textures are not required. For now, this is only linked up to replace the hurt textures.

To use this, a ShaderMaterial must be placed on the Sprite object of an entity and the shader must be assigned to it, if this is not done by hand, it will automatically be added to any entity with some default values. Additional work will need to be done to sync colors over the network.

For the "custom_colors" option to function properly, a spritesheet must be passed in where the color values are presented like so:

Skin: #FFFFFF (White)
Outline: #00000 (Black)
Accent: #FF00FF (Pink)