### PR TITLE
Changed WalkUp Animation

### DIFF
--- a/player/player.tscn
+++ b/player/player.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://player/player.gd" type="Script" id=1]
 [ext_resource path="res://player/player2.png" type="Texture" id=2]
-[ext_resource path="res://ui/monogram.ttf" type="DynamicFontData" id=4]
+[ext_resource path="res://ui/monogram.ttf" type="DynamicFontData" id=3]
 
 [sub_resource type="Animation" id=1]
 resource_name = "idleDown"
@@ -324,7 +324,7 @@ tracks/0/keys = {
 "times": PoolRealArray( 0, 0.5 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
-"values": [ 4, 5 ]
+"values": [ 5, 4 ]
 }
 
 [sub_resource type="RectangleShape2D" id=19]
@@ -333,7 +333,7 @@ extents = Vector2( 4.5, 6 )
 [sub_resource type="DynamicFont" id=20]
 outline_size = 1
 outline_color = Color( 0, 0, 0, 1 )
-font_data = ExtResource( 4 )
+font_data = ExtResource( 3 )
 
 [node name="Player" type="KinematicBody2D"]
 z_index = 10


### PR DESCRIPTION
This is a simple change to WalkUp Animation. I notice that the walkup animation doesn't play when the user make a small movement to up:

Old:
![not_fixed](https://media.giphy.com/media/W2Kk3kQFLJM4OoUJPs/giphy.gif)

Fixed:
![fixed](https://media.giphy.com/media/idvhtOskjpK2VNQCPZ/giphy.gif)