### PR TITLE
changed save location for preferences

### DIFF
--- a/engine/settings.gd
+++ b/engine/settings.gd
@@ -7,8 +7,7 @@ const schema_version: String = "0"
 const server_version: String = "0"
 
 const _user_dir: String = "user://"
-const _save_location: String = "tetraforce"
-const _preference_file: String = "preferences.tf"
+const _preference_file: String = "preferences.json"
 
 const default_host: String = "127.0.0.1"
 
@@ -59,10 +58,10 @@ func _ready() -> void:
 	_load_from_preferences()
 		
 func _get_save_file() -> String:
-	return _user_dir + _save_location + _preference_file
+	return _user_dir + _preference_file
 	
 func _get_save_dir() -> String:
-	return _user_dir + _save_location
+	return _user_dir
 
 func _load_from_preferences() -> void:
 	var saved = File.new()


### PR DESCRIPTION
The code to save preferences had a bug regarding the concatenation of strings. I guess it was intended to have a subfolder "tetraforce" and a file "preferences.tf" in there.

As it turns out, that subfolder was created, but it never contained any items. Instead, a file called "tetraforcepreferences.tf" was created.

This change removed the unnecessary subfolder (because Godot sets the user:// root folder to a subdirectory of the project name already) and switches the extension to json to better reflect its contents.

![Screenshot from 2019-11-03 11-06-28](https://user-images.githubusercontent.com/1500105/68083663-8e8a7c00-fe2b-11e9-942e-6aea318ea7f7.png)

If you checked out an earlier version of the game, you still have to manually remove the empty "tetraforce" (all lowercase!) directory and "tetraforcepreferences.tf" settings file.
