### PR TITLE
Room class

### DIFF
--- a/engine/entity.gd
+++ b/engine/entity.gd
@@ -39,6 +39,8 @@ onready var camera = get_parent().get_node("Camera")
 var texture_default = null
 var entity_shader = preload("res://engine/entity.shader")
 
+var room : network.Room
+
 func _ready():
 	
 	texture_default = sprite.texture
@@ -52,6 +54,9 @@ func _ready():
 	health = MAX_HEALTH
 	home_position = position
 	create_hitbox()
+	
+	room = network.get_room(position)
+	room.add_entity(self)
 
 func create_hitbox():
 	var new_hitbox = Area2D.new()
@@ -205,6 +210,7 @@ func choose_subitem(possible_drops, drop_chance):
 sync func enemy_death():
 	if is_scene_owner():
 		choose_subitem(["HEALTH", "RUPEE"], 100)
+	room.remove_entity(self)
 	var death_animation = preload("res://enemies/enemy_death.tscn").instance()
 	death_animation.global_position = global_position
 	get_parent().add_child(death_animation)

--- a/player/player.gd
+++ b/player/player.gd
@@ -204,9 +204,12 @@ func connect_camera():
 
 func screen_change_started():
 	set_physics_process(false)
+	room.remove_entity(self)
 
 func screen_change_completed():
 	set_physics_process(true)
+	room = network.get_room(position)
+	room.add_entity(self)
 
 func _on_HoldTimer_timeout():
 	spinAtk = true


### PR DESCRIPTION
Added a Room class. This class is useful for event that require room informations such as the enemy count in issue #7.

At the moment it contains arrays of the entities inside the room and provides player_entered, player_exited and enemies_defeated signals. The room is freed when everyone exits it.

Rooms can be accessed from the network singleton. Entities have a room variable that references the room they're in.

Current issues:
- Players' current room is updated only locally. So the rooms aren't properly synced and freed.