### PR TITLE
Remove item_resources and update_item_resources()

### DIFF
--- a/player/player.gd
+++ b/player/player.gd
@@ -8,7 +8,6 @@ var push_target = null
 # synced from engine/global.gd
 var equip_slot
 var items
-var item_resources
 
 var spinAtk = false
 onready var holdTimer = $HoldTimer
@@ -29,7 +28,6 @@ func _ready():
 	add_to_group("player")
 	ray.add_exception(hitbox)
 	
-	update_item_resources()
 	connect_camera()
 	
 	$PlayerName.visible = settings.get_pref("show_name_tags")
@@ -200,12 +198,6 @@ func show_chat():
 	network.current_map.get_node("HUD").add_child(chat)
 	chat.message_log = chat_messages
 	chat.start()
-
-func update_item_resources():
-	item_resources = []
-	for item in items:
-		item_resources.append(global.get_item_path(item))
-	print(item_resources)
 
 func connect_camera():
 	camera.connect("screen_change_started", self, "screen_change_started")

--- a/ui/inventory/inventory.gd
+++ b/ui/inventory/inventory.gd
@@ -16,8 +16,7 @@ func start():
 	add_items()
 
 func add_items():
-	for item in player.item_resources:
-		var item_name = global.get_item_name(item)
+	for item_name in player.items:
 		var new_label = Label.new()
 		item_list.add_child(new_label)
 		new_label.owner = self


### PR DESCRIPTION
inventory.gd was using item_resources, instead of items, get item names.
Since item_resources isn't used anywhere else, I removed it and update_item_resources(), which was causing errors in multiplayer.