### PR TITLE
Additional improvements to CI/CD pipeline

### DIFF
--- a/.github/workflows/build_dev_server.yml
+++ b/.github/workflows/build_dev_server.yml
@@ -1,0 +1,50 @@
+name: Build Dev Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag onto Docker image"
+        default: "dev"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: get_tag
+        name: Get Tag
+        env:
+          GITHUB_HEAD_REF: $${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "${{ github.event.inputs.version }}" = "" ]
+          then
+            TAG=$(jq --raw-output '.release.tag_name' $GITHUB_EVENT_PATH)
+          else
+            TAG=${{ github.event.inputs.version }}
+          fi
+          
+          echo ::set-output name=TAG::$TAG
+      - name: Build Godot Project
+        id: build
+        uses: josephbmanley/build-godot-action@v1.4.0
+        with:
+          name: TetraForce
+          preset: linux
+          projectDir: '.'
+          debugMode: 'true'
+      - name: Push Tag to GitHub Package
+        uses: opspresso/action-docker@master
+        with:
+          args: --docker
+        env:
+          USERNAME: ${{ github.actor }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY: "docker.pkg.github.com/fornclake/tetraforce"
+          BUILD_PATH: "."
+          DOCKERFILE: "Dockerfile"
+          IMAGE_NAME: "tetraforce"
+          TAG_NAME: ${{ steps.get_tag.outputs.TAG }}
+          LATEST: "false"

--- a/.github/workflows/build_godot.yml
+++ b/.github/workflows/build_godot.yml
@@ -2,6 +2,7 @@ name: Build Godot Project
 
 on:
   push: {}
+  pull_request: {}
 
 jobs:
   godot:

--- a/.github/workflows/build_godot.yml
+++ b/.github/workflows/build_godot.yml
@@ -1,8 +1,7 @@
-name: Build Project
+name: Build Godot Project
 
 on:
   push: {}
-  workflow_dispatch: {}
 
 jobs:
   godot:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,14 +1,9 @@
-name: Build Docker Image
+name: Publish Release
 
 on:
   release:
     types:
       - created
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version number of name of build."
-        default: "dev"
 
 jobs:
   docker:
@@ -37,6 +32,7 @@ jobs:
           name: TetraForce
           preset: linux
           projectDir: '.'
+          debugMode: 'true'
       - name: Push Tag to GitHub Package
         uses: opspresso/action-docker@master
         with:
@@ -49,17 +45,27 @@ jobs:
           DOCKERFILE: "Dockerfile"
           IMAGE_NAME: "tetraforce"
           TAG_NAME: ${{ steps.get_tag.outputs.TAG }}
-          LATEST: "false"
-      - name: Push Latest to GitHub Package
-        uses: opspresso/action-docker@master
-        with:
-          args: --docker
-        env:
-          USERNAME: ${{ github.actor }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY: "docker.pkg.github.com/fornclake/tetraforce"
-          BUILD_PATH: "."
-          DOCKERFILE: "Dockerfile"
-          IMAGE_NAME: "tetraforce"
-          TAG_NAME: ${{ steps.get_tag.outputs.TAG }}
           LATEST: "true"
+  godot:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux, osx, win32, win64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configure
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          if [ "$PLATFORM" = "win32" ] || [ "$PLATFORM" = "win64" ] ; then
+            echo "::set-env name=EXPORT_SUFFIX::.exe"
+          fi
+      - name: Build
+        id: build
+        uses: josephbmanley/build-godot-action@v1.4.0
+        with:
+          name: TetraForce${{ env.EXPORT_SUFFIX }}
+          preset: ${{ matrix.platform }}
+          projectDir: '.'
+      # In the future a push to itch or other platform would go here

--- a/.github/workflows/build_stage_server.yml
+++ b/.github/workflows/build_stage_server.yml
@@ -1,0 +1,33 @@
+name: Build Stage Image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build Godot Project
+        id: build
+        uses: josephbmanley/build-godot-action@v1.4.0
+        with:
+          name: TetraForce
+          preset: linux
+          projectDir: '.'
+      - name: Push Tag to GitHub Package
+        uses: opspresso/action-docker@master
+        with:
+          args: --docker
+        env:
+          USERNAME: ${{ github.actor }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY: "docker.pkg.github.com/fornclake/tetraforce"
+          BUILD_PATH: "."
+          DOCKERFILE: "Dockerfile"
+          IMAGE_NAME: "tetraforce"
+          TAG_NAME: stage
+          LATEST: "false"


### PR DESCRIPTION
Updates CI/CD pipeline to split project in stages. This allows the production environment to remain stable, while stage and dev environments can have non-tested code.

Pipeline: Dev -> Stage -> Production

Dev: Any manual workflow trigger can create a dev image with a custom tag. The custom tag can then be deployed to a dev environment (I'll write more documentation about this at some point)

Stage: `master` branch

Production: GitHub release & correlating tag

Every time there is a release to production, the container will get the `latest` tag. Anytime there is a push to master, the container will get the `stage` tag. The similar pipeline exists currently for the infrastructure.

![Pipeline Flow](https://app.lucidchart.com/publicSegments/view/cc4485c9-da2c-43fc-b90b-7864e7ce0489/image.png)

Closes https://github.com/josephbmanley/tetraforce-infrastructure/issues/13