### PR TITLE
PIPELINE: Fixed Docker Push Errors on Forks

### DIFF
--- a/.github/workflows/build_dev_server.yml
+++ b/.github/workflows/build_dev_server.yml
@@ -35,6 +35,11 @@ jobs:
           preset: linux
           projectDir: '.'
           debugMode: 'true'
+      - name: Get Docker Repo Name
+        id: find_repo
+        run: |
+          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo ::set-output name=REPO::$REPO
       - name: Push Tag to GitHub Package
         uses: opspresso/action-docker@master
         with:
@@ -42,7 +47,7 @@ jobs:
         env:
           USERNAME: ${{ github.actor }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY: "docker.pkg.github.com/fornclake/tetraforce"
+          REGISTRY: "docker.pkg.github.com/${{ steps.find_repo.outputs.REPO }}"
           BUILD_PATH: "."
           DOCKERFILE: "Dockerfile"
           IMAGE_NAME: "tetraforce"

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -33,6 +33,11 @@ jobs:
           preset: linux
           projectDir: '.'
           debugMode: 'true'
+      - name: Get Docker Repo Name
+        id: find_repo
+        run: |
+          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo ::set-output name=REPO::$REPO
       - name: Push Tag to GitHub Package
         uses: opspresso/action-docker@master
         with:
@@ -40,7 +45,7 @@ jobs:
         env:
           USERNAME: ${{ github.actor }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY: "docker.pkg.github.com/fornclake/tetraforce"
+          REGISTRY: "docker.pkg.github.com/${{ steps.find_repo.outputs.REPO }}"
           BUILD_PATH: "."
           DOCKERFILE: "Dockerfile"
           IMAGE_NAME: "tetraforce"

--- a/.github/workflows/build_stage_server.yml
+++ b/.github/workflows/build_stage_server.yml
@@ -18,6 +18,11 @@ jobs:
           name: TetraForce
           preset: linux
           projectDir: '.'
+      - name: Get Docker Repo Name
+        id: find_repo
+        run: |
+          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo ::set-output name=REPO::$REPO
       - name: Push Tag to GitHub Package
         uses: opspresso/action-docker@master
         with:
@@ -25,7 +30,7 @@ jobs:
         env:
           USERNAME: ${{ github.actor }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY: "docker.pkg.github.com/fornclake/tetraforce"
+          REGISTRY: "docker.pkg.github.com/${{ steps.find_repo.outputs.REPO }}"
           BUILD_PATH: "."
           DOCKERFILE: "Dockerfile"
           IMAGE_NAME: "tetraforce"


### PR DESCRIPTION
When building the docker images on forks, the build would fail because it would not have permissions to push to the main TetraForce repository. This has been solved by formatting the Git repo name and using it to push to the fork's Docker repo.