### PR TITLE
fixing up empty-server-timeout

### DIFF
--- a/engine/main.gd
+++ b/engine/main.gd
@@ -53,16 +53,35 @@ func _ready():
 		get_node("panel/address").set_text("127.0.0.1:" + arguments["port"])
 	
 	if OS.get_name() == "Server" || arguments.get("dedicatedserver") == "true":
-		var empty_timeout = 0
-		var empty_timeout_arg = arguments.get("empty-server-timeout", 60)
-		#if empty_timeout_arg.is_valid_integer():
-		#	var empty_timeout_arg_int = int(empty_timeout_arg)
-		#	if empty_timeout_arg_int > 0:
-		#		empty_timeout = empty_timeout_arg_int
-		print(empty_timeout_arg)
+		var empty_timeout = get_empty_server_timeout(arguments)
 		set_dedicated_server(empty_timeout)
 	
 	#print(yield(server_api.get_servers(), "completed"))
+
+func get_empty_server_timeout(arguments):
+	var empty_timeout
+	
+	var empty_timeout_arg = arguments.get("empty-server-timeout")   # don't set default here
+	if empty_timeout_arg != null:
+		if empty_timeout_arg.is_valid_integer():
+			var empty_timeout_arg_int = int(empty_timeout_arg)
+			if empty_timeout_arg_int >= 0:
+				empty_timeout = empty_timeout_arg_int
+			else:
+				print("invalid value for empty-server-timeout - must be an integer >= 0")
+		else:
+			print("invalid value for empty-server-timeout - must be an integer >= 0")
+	
+	if empty_timeout == null:
+		empty_timeout = 0   # set default here
+		print("defaulting empty-server-timeout to %d" % empty_timeout)
+	
+	if empty_timeout > 0:
+		print("empty-server-timeout set to %d seconds" % empty_timeout)
+	else:
+		print("empty-server-timeout set to 0 - server will not stop when empty")
+	
+	return empty_timeout
 
 func start_game(dedicated = false, empty_timeout = 0):
 	if dedicated:


### PR DESCRIPTION
Moved the logic for `empty-server-timeout` to its own function, fixed it up a bit, and added some logging.

At some point we talked about the default should be `0` because that will be easiest for anyone that wants to run their own server.  That does mean we'll have to pass `--empty-server-timeout=60` for the AWS servers.

And the reason for the extra user friendly validation and logging is for the same reason, someone other than devs may try to set up a server, and I think it would be best if it's easy to see if they did something wrong.  