### PR TITLE
Add public servers section to multiplayer

### DIFF
--- a/engine/main.gd
+++ b/engine/main.gd
@@ -1,3 +1,4 @@
+class_name Main
 extends Control
 
 var default_map = "res://maps/shrine.tmx"

--- a/engine/main.tscn
+++ b/engine/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://ui/theme/theme.tres" type="Theme" id=1]
 [ext_resource path="res://ui/options/options.tscn" type="PackedScene" id=2]
@@ -7,6 +7,7 @@
 [ext_resource path="res://ui/player_select/player_select.tscn" type="PackedScene" id=5]
 [ext_resource path="res://ui/logo_animated_sprite.tres" type="SpriteFrames" id=6]
 [ext_resource path="res://ui/loading_screen/loading_screen.tscn" type="PackedScene" id=7]
+[ext_resource path="res://ui/main/public_servers.gd" type="Script" id=8]
 
 [node name="main" type="Control"]
 anchor_right = 1.0
@@ -41,6 +42,7 @@ animation = "Logo"
 [node name="top" type="Panel" parent="." groups=[
 "menu",
 ]]
+visible = false
 margin_left = 176.0
 margin_top = 117.572
 margin_right = 336.0
@@ -116,7 +118,6 @@ __meta__ = {
 [node name="multiplayer" type="TabContainer" parent="." groups=[
 "menu",
 ]]
-visible = false
 margin_left = 144.0
 margin_top = 98.0
 margin_right = 368.0
@@ -125,7 +126,54 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="Public" type="Control" parent="multiplayer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 8.99585
+margin_top = 29.9958
+margin_right = -9.51308
+margin_bottom = -9.11333
+script = ExtResource( 8 )
+_main = NodePath("../..")
+_button_container = NodePath("ScrollContainer/VBoxContainer")
+
+[node name="Label" type="Label" parent="multiplayer/Public"]
+margin_right = 210.0
+margin_bottom = 31.0
+text = "Join other players in solving puzzles and fighting bosses!"
+align = 1
+autowrap = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ScrollContainer" type="ScrollContainer" parent="multiplayer/Public"]
+margin_left = 2.0
+margin_top = 34.0
+margin_right = 201.0
+margin_bottom = 139.0
+scroll_horizontal_enabled = false
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer" type="VBoxContainer" parent="multiplayer/Public/ScrollContainer"]
+margin_right = 199.0
+margin_bottom = 21.0
+size_flags_horizontal = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Button" type="Button" parent="multiplayer/Public/ScrollContainer/VBoxContainer"]
+margin_right = 199.0
+margin_bottom = 21.7537
+size_flags_horizontal = 3
+text = "#0 Public Server"
+align = 0
+
 [node name="Automatic" type="Control" parent="multiplayer"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 8.99585
@@ -162,7 +210,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Manual" type="Control" parent="multiplayer"]
+[node name="Direct" type="Control" parent="multiplayer"]
 visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -173,7 +221,7 @@ margin_bottom = -9.11333
 size_flags_horizontal = 2
 size_flags_vertical = 2
 
-[node name="Label" type="Label" parent="multiplayer/Manual"]
+[node name="Label" type="Label" parent="multiplayer/Direct"]
 margin_right = 199.0
 margin_bottom = 146.0
 text = "Host a server on this machine by pressing the button below.
@@ -187,7 +235,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="address" type="LineEdit" parent="multiplayer/Manual"]
+[node name="address" type="LineEdit" parent="multiplayer/Direct"]
 margin_left = 8.0
 margin_top = 114.0
 margin_right = 136.0
@@ -199,7 +247,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="host" type="Button" parent="multiplayer/Manual"]
+[node name="host" type="Button" parent="multiplayer/Direct"]
 margin_left = 71.0042
 margin_top = 66.0042
 margin_right = 135.004
@@ -211,7 +259,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="join" type="Button" parent="multiplayer/Manual"]
+[node name="join" type="Button" parent="multiplayer/Direct"]
 margin_left = 142.0
 margin_top = 120.0
 margin_right = 206.0
@@ -280,7 +328,7 @@ visible = false
 [connection signal="mouse_entered" from="top/VBoxContainer/quit" to="." method="_on_mouse_entered"]
 [connection signal="pressed" from="top/VBoxContainer/quit" to="." method="_on_quit_pressed"]
 [connection signal="pressed" from="multiplayer/Automatic/connect" to="." method="_on_connect_pressed"]
-[connection signal="pressed" from="multiplayer/Manual/host" to="." method="_on_host_pressed"]
-[connection signal="pressed" from="multiplayer/Manual/join" to="." method="_on_join_pressed"]
+[connection signal="pressed" from="multiplayer/Direct/host" to="." method="_on_host_pressed"]
+[connection signal="pressed" from="multiplayer/Direct/join" to="." method="_on_join_pressed"]
 [connection signal="mouse_entered" from="back" to="." method="_on_mouse_entered"]
 [connection signal="pressed" from="back" to="." method="_on_back_pressed"]

--- a/project.godot
+++ b/project.godot
@@ -34,6 +34,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://tiles/holes.gd"
 }, {
+"base": "Control",
+"class": "Main",
+"language": "GDScript",
+"path": "res://engine/main.gd"
+}, {
 "base": "KinematicBody2D",
 "class": "NPC",
 "language": "GDScript",
@@ -70,6 +75,7 @@ _global_script_class_icons={
 "Enemy": "",
 "Entity": "",
 "Holes": "",
+"Main": "",
 "NPC": "",
 "Player": "",
 "SaveDisplay": "",

--- a/ui/main/public_servers.gd
+++ b/ui/main/public_servers.gd
@@ -1,0 +1,48 @@
+extends Control
+
+export(int) var number_of_servers = 2
+export(NodePath) var _main
+export(NodePath) var _button_container
+
+export(Array, String) var name_gen_first_part = [ "Tetra", "First", "Second", "Third", "Fourth" ]
+export(Array, String) var name_gen_middle_part = [ "of" ]
+export(Array, String) var name_gen_end_part = [ "Friends", "Force" ]
+export(Array, String) var name_gen_any_part = [ "Sword", "Bow", "Dungeon", "Fire", "Doom", "Chain",
+		"Knot", "Key", "Pirate", "Bat", "Knawblin", "Cucukin", "Village" ]
+
+var main : Main
+var button_container : Control
+
+func _ready():
+	main = get_node(_main)
+	button_container = get_node(_button_container)
+	
+	for child in button_container.get_children():
+		child.queue_free()
+	
+	for i in range(number_of_servers):
+		var server_name = generate_server_name(i)
+		button_container.add_child(create_server_button("#%s %s" % [i+1, server_name],server_name))
+
+func create_server_button(server_label : String, server_name : String) -> Node:
+	var button = Button.new()
+	button.connect("button_down", main, "join_aws", [server_name])
+	button.align = Button.ALIGN_LEFT
+	button.text = server_label
+	return button
+
+func get_version_as_int() -> int:
+	var spb = StreamPeerBuffer.new()
+	spb.data_array = global.get_version().to_utf8()
+	return spb.get_64()
+
+func generate_server_name(randomizer_seed : int) -> String:
+	var rand = RandomNumberGenerator.new()
+	rand.seed = randomizer_seed + get_version_as_int()
+	var possible_first = name_gen_first_part + name_gen_any_part
+	var first = possible_first[rand.randi_range(0,len(possible_first)-1)]
+	var possible_middle = name_gen_middle_part + name_gen_any_part
+	var middle = possible_middle[rand.randi_range(0,len(possible_middle)-1)]
+	var possible_end = name_gen_end_part + name_gen_any_part
+	var end = possible_end[rand.randi_range(0,len(possible_end)-1)]
+	return first + "-" + middle + "-" + end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21203171/138586152-a3bebe5e-6568-43ec-a556-1ff37cb1de4c.png)

### Summary
Added a public servers section to multiplayer to encourage players to easily play online with others.

- Server names are randomly generated on client (seeded)
- Server name generation seed is affected by version, this means the server names will be updated with every version to avoid version mismatch during updates
- To increase public server count or change name generator, you can make tweaks in the inspector ![image](https://user-images.githubusercontent.com/21203171/138586199-4b7db11c-3116-47c1-a880-d3cc3276aa32.png)

### Testing

1. Click "Multiplayer" and select a lobby
2. After the server is created you should get a version mismatch error and be disconnected (see output). 

Additionally every time you start the game, the lobby names should remain the same unless you update the version file.

[**Has this been tested in multiplayer?**](https://github.com/loudsmilestudios/TetraForce/wiki/How-to-test-multiplayer) *yes* (even hacked it to connect to `v0.4.0` servers)
